### PR TITLE
Simplify CSS to not be redundant, kill lines that weren't applying

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,6 +4,7 @@ body {
     text-shadow: 3px 3px red;
     text-align: center;
     margin: 0;
+    font-size: 21px;
 }
 
 /* set up the table row, title and body  */
@@ -39,24 +40,4 @@ body {
 .plrName {
     width: 1400px;
     text-align: left;
-}
-
-/* Sizes for scoring players trNum00 is default for all players past the 5th position */
-.trNum00{
-  font-size: 21px;
-}
-.trNum01{
-  font-size: 80px;
-}
-.trNum02{
-  font-size: 70px
-}
-.trNum03{
-  font-size: 60px
-}
-.trNum04{
-  font-size: 50px
-}
-.trNum05{
-  font-size: 45px
 }

--- a/style.css
+++ b/style.css
@@ -1,52 +1,45 @@
-#leaderboard tr {
+/* Set default font for all elements */
+body {
     font-family: 'Press Start 2P', cursive;
-    color: rgb(255, 255, 0);
     text-shadow: 3px 3px red;
+    text-align: center;
+    margin: 0;
+}
+
+/* set up the table row, title and body  */
+#leaderboard tr {
+    color: rgb(255, 255, 0);
     text-transform: uppercase;
     padding-bottom: 1%;
     white-space: nowrap;
-    overflow: hidden;
 }
 #leaderboard {
-    position:absolute;
-    top: 0px;
     padding-top:20px;
     padding-left:20px;
-    left: 0px;
     width: 1920px;
     height: 1080px;
     background: #00ff00;
     overflow: hidden;
-    
 }
 #title {
-    font-family: 'Press Start 2P', cursive;
-    text-shadow: 3px 3px red;
     color: orange;
-    width: 100%;
     height: 80px;
     font-weight: 600;
     font-size: 60px;
-    text-align: center;
 }
 
-/* styles for the 3 main fields */
+/* styles for the 3 columns of content in the table */
 .plrRnk{
     padding-right: 30px;
-    text-align: center;
     width: 175px;
 }
-.plrScore{
-    position: absolute;
+.plrScore {
     width: 210px;
-    align-content: center;
-    text-align: center;
-    overflow: hidden;
 }
 .plrName {
     width: 1400px;
+    text-align: left;
 }
-
 
 /* Sizes for scoring players trNum00 is default for all players past the 5th position */
 .trNum00{


### PR DESCRIPTION
@PongAlmighty - this should be identical to `main` as just about all the chagnes in this PR remove CSS that didn't actually do anything (including all the `trNum--` classes. 

If we want the player name to not push the score off to the right, the CSS we had wouldn't have worked.  [See this blog post](https://www.w3docs.com/snippets/css/how-to-make-the-css-overflow-hidden-work-on-a-td-element.html) for a future PR! Otherwise, we're capped at ~40 chars per username in the `#1` slot. 